### PR TITLE
Fix: Update Telegram message date parsing and add tests

### DIFF
--- a/internal/sources/telegram_test.go
+++ b/internal/sources/telegram_test.go
@@ -22,9 +22,11 @@ func Test_processMessage(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Valid message",
-			now:  time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 8, 19, 0, 0, time.UTC),
-			text: `🚨 ירי רקטות וטילים [10/10/2024] 11:19
+			name: "Original Valid message (updated format)",
+			// Message time: (10/10/2024) 11:19 IDT. For UTC, assuming IDT is UTC+3, this is 08:19 UTC.
+			// "now" is 30 seconds after message time.
+			now: time.Date(2024, 10, 10, 8, 19, 30, 0, time.UTC),
+			text: `🚨 ירי רקטות וטילים (10/10/2024) 11:19
 
 אזור קו העימות
 מטולה (מיידי)
@@ -34,12 +36,76 @@ func Test_processMessage(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Expired message",
-			now:  time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), 8, 22, 0, 0, time.UTC),
-			text: `🚨 ירי רקטות וטילים [10/10/2024] 11:19
+			name: "Original Expired message (updated format)",
+			// Message time: (10/10/2024) 11:19 IDT (08:19 UTC)
+			// "now" is 121 seconds after message time (08:21:01 UTC)
+			now: time.Date(2024, 10, 10, 8, 21, 1, 0, time.UTC),
+			text: `🚨 ירי רקטות וטילים (10/10/2024) 11:19
 
 אזור קו העימות
 מטולה (מיידי)
+
+היכנסו למרחב המוגן ושהו בו למשך 10 דקות.
+להנחיות המלאות - https://www.oref.org.il/heb/life-saving-guidelines/rocket-and-missile-attacks`,
+			wantErr: true,
+		},
+		{
+			name: "New Message 1 - Non-expired",
+			// Message time: (29/05/2025) 21:23 IDT. Assuming IDT is UTC+3, this is 18:23 UTC.
+			// "now" is 30 seconds after message time.
+			now: time.Date(2025, 5, 29, 18, 23, 30, 0, time.UTC),
+			text: `🚨 ירי רקטות וטילים (29/5/2025) 21:23
+
+אזור שומרון
+דולב, טלמון, נריה (דקה וחצי)
+
+היכנסו למרחב המוגן ושהו בו למשך 10 דקות.
+להנחיות המלאות - https://www.oref.org.il/heb/life-saving-guidelines/rocket-and-missile-attacks`,
+			wantErr: false,
+		},
+		{
+			name: "New Message 1 - Expired",
+			// Message time: (29/05/2025) 21:23 IDT (18:23 UTC)
+			// "now" is 120 seconds after message time (18:25:00 UTC)
+			now: time.Date(2025, 5, 29, 18, 25, 0, 0, time.UTC),
+			text: `🚨 ירי רקטות וטילים (29/5/2025) 21:23
+
+אזור שומרון
+דולב, טלמון, נריה (דקה וחצי)
+
+היכנסו למרחב המוגן ושהו בו למשך 10 דקות.
+להנחיות המלאות - https://www.oref.org.il/heb/life-saving-guidelines/rocket-and-missile-attacks`,
+			wantErr: true,
+		},
+		{
+			name: "New Message 2 - Non-expired",
+			// Message time: (29/05/2025) 21:22 IDT (18:22 UTC)
+			// "now" is 30 seconds after message time.
+			now: time.Date(2025, 5, 29, 18, 22, 30, 0, time.UTC),
+			text: `🚨 ירי רקטות וטילים (29/5/2025) 21:22
+
+אזור השפלה
+גאליה (דקה)
+
+אזור לכיש
+בית אלעזרי, בית גמליאל, יבנה, כפר הנגיד, מעון צופיה, מפעל אגריגדה  (דקה)
+
+היכנסו למרחב המוגן ושהו בו למשך 10 דקות.
+להנחיות המלאות - https://www.oref.org.il/heb/life-saving-guidelines/rocket-and-missile-attacks`,
+			wantErr: false,
+		},
+		{
+			name: "New Message 2 - Expired",
+			// Message time: (29/05/2025) 21:22 IDT (18:22 UTC)
+			// "now" is 120 seconds after message time (18:24:00 UTC)
+			now: time.Date(2025, 5, 29, 18, 24, 0, 0, time.UTC),
+			text: `🚨 ירי רקטות וטילים (29/5/2025) 21:22
+
+אזור השפלה
+גאליה (דקה)
+
+אזור לכיש
+בית אלעזרי, בית גמליאל, יבנה, כפר הנגיד, מעון צופיה, מפעל אגריגדה  (דקה)
 
 היכנסו למרחב המוגן ושהו בו למשך 10 דקות.
 להנחיות המלאות - https://www.oref.org.il/heb/life-saving-guidelines/rocket-and-missile-attacks`,


### PR DESCRIPTION
The pubDate extraction logic for Telegram messages has been updated to support the new format (DD/MM/YYYY) HH:MM.

Previously, the code expected a time string like HH:MM and prepended the current system date, which failed when the date format in messages changed.

Changes:
- Modified `extractPubTimeRe` regex to capture the full "DD/MM/YYYY HH:MM" pattern.
- Updated `extractPubTime` function to return the combined date and time string, ensuring day and month are zero-padded if single-digit.
- Adjusted `checkExpired` function to parse this combined string using the "02/01/2006 15:04" layout and removed the prepending of the current date.
- Added new test cases in `Test_processMessage` for the specific messages reported in the issue, covering both non-expired and expired scenarios.
- Updated existing tests to use the new date format.

All tests in ./internal/sources/... pass with these changes.